### PR TITLE
An alternative approach to removing `UnknownBufferType`

### DIFF
--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -40,23 +40,15 @@ fn main() -> Result<(), anyhow::Error> {
         eprintln!("an error occurred on stream: {}", err);
     };
 
-    let stream = match format.data_type {
-        cpal::SampleFormat::F32 => device.build_input_stream(
-            &format,
-            move |data| write_input_data::<f32, f32>(&*data, &writer_2),
-            err_fn,
-        ),
-        cpal::SampleFormat::I16 => device.build_input_stream(
-            &format,
-            move |data| write_input_data::<i16, i16>(&*data, &writer_2),
-            err_fn,
-        ),
-        cpal::SampleFormat::U16 => device.build_input_stream(
-            &format,
-            move |data| write_input_data::<u16, i16>(&*data, &writer_2),
-            err_fn,
-        ),
-    }?;
+    let data_fn = move |data: &cpal::Data| {
+        match data.sample_format() {
+            cpal::SampleFormat::F32 => write_input_data::<f32, f32>(data, &writer_2),
+            cpal::SampleFormat::I16 => write_input_data::<i16, i16>(data, &writer_2),
+            cpal::SampleFormat::U16 => write_input_data::<u16, i16>(data, &writer_2),
+        }
+    };
+
+    let stream = device.build_input_stream(&format, data_fn, err_fn)?;
 
     stream.play()?;
 
@@ -87,11 +79,12 @@ fn wav_spec_from_format(format: &cpal::Format) -> hound::WavSpec {
 
 type WavWriterHandle = Arc<Mutex<Option<hound::WavWriter<BufWriter<File>>>>>;
 
-fn write_input_data<T, U>(input: &[T], writer: &WavWriterHandle)
+fn write_input_data<T, U>(input: &cpal::Data, writer: &WavWriterHandle)
 where
     T: cpal::Sample,
     U: cpal::Sample + hound::Sample,
 {
+    let input = input.as_slice::<T>().expect("unexpected sample format");
     if let Ok(mut guard) = writer.try_lock() {
         if let Some(writer) = guard.as_mut() {
             for &sample in input.iter() {

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -3,15 +3,13 @@ extern crate parking_lot;
 
 use crate::{
     BuildStreamError,
+    Data,
     DefaultFormatError,
     DeviceNameError,
     DevicesError,
     Format,
-    InputData,
-    OutputData,
     PauseStreamError,
     PlayStreamError,
-    Sample,
     StreamError,
     SupportedFormatsError,
 };
@@ -91,29 +89,27 @@ impl DeviceTrait for Device {
         Device::default_output_format(self)
     }
 
-    fn build_input_stream<T, D, E>(
+    fn build_input_stream<D, E>(
         &self,
         format: &Format,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
     where
-        T: Sample,
-        D: FnMut(InputData<T>) + Send + 'static,
+        D: FnMut(&Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static
     {
         Device::build_input_stream(self, format, data_callback, error_callback)
     }
 
-    fn build_output_stream<T, D, E>(
+    fn build_output_stream<D, E>(
         &self,
         format: &Format,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
     where
-        T: Sample,
-        D: FnMut(OutputData<T>) + Send + 'static,
+        D: FnMut(&mut Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static
     {
         Device::build_output_stream(self, format, data_callback, error_callback)

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -1,11 +1,10 @@
 use crate::{
     BuildStreamError,
+    Data,
     DefaultFormatError,
     DevicesError,
     DeviceNameError,
     Format,
-    InputData,
-    OutputData,
     PauseStreamError,
     PlayStreamError,
     StreamError,
@@ -71,28 +70,28 @@ impl DeviceTrait for Device {
         unimplemented!()
     }
 
-    fn build_input_stream<T, D, E>(
+    fn build_input_stream<D, E>(
         &self,
         _format: &Format,
         _data_callback: D,
         _error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
     where
-        D: FnMut(InputData<T>) + Send + 'static,
+        D: FnMut(&Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
         unimplemented!()
     }
 
     /// Create an output stream.
-    fn build_output_stream<T, D, E>(
+    fn build_output_stream<D, E>(
         &self,
         _format: &Format,
         _data_callback: D,
         _error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
     where
-        D: FnMut(OutputData<T>) + Send + 'static,
+        D: FnMut(&mut Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
         unimplemented!()

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -1,12 +1,10 @@
 use crate::{
     BackendSpecificError,
+    Data,
     DefaultFormatError,
     DeviceNameError,
     DevicesError,
     Format,
-    InputData,
-    OutputData,
-    Sample,
     SampleFormat,
     SampleRate,
     SupportedFormat,
@@ -106,30 +104,28 @@ impl DeviceTrait for Device {
         Device::default_output_format(self)
     }
 
-    fn build_input_stream<T, D, E>(
+    fn build_input_stream<D, E>(
         &self,
         format: &Format,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
     where
-        T: Sample,
-        D: FnMut(InputData<T>) + Send + 'static,
+        D: FnMut(&Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
         let stream_inner = self.build_input_stream_inner(format)?;
         Ok(Stream::new_input(stream_inner, data_callback, error_callback))
     }
 
-    fn build_output_stream<T, D, E>(
+    fn build_output_stream<D, E>(
         &self,
         format: &Format,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
     where
-        T: Sample,
-        D: FnMut(OutputData<T>) + Send + 'static,
+        D: FnMut(&mut Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
         let stream_inner = self.build_output_stream_inner(format)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,14 @@ pub struct Data {
 
 impl Data {
     // Internal constructor for host implementations to use.
+    //
+    // The following requirements must be met in order for the safety of `Data`'s public API.
+    //
+    // - The `data` pointer must point to the first sample in the slice containing all samples.
+    // - The `len` must describe the length of the buffer as a number of samples in the expected
+    //   format specified via the `sample_format` argument.
+    // - The `sample_format` must correctly represent the underlying sample data delivered/expected
+    //   by the stream.
     pub(crate) unsafe fn from_parts(
         data: *mut (),
         len: usize,
@@ -228,9 +236,11 @@ impl Data {
 
     /// The raw slice of memory representing the underlying audio data as a slice of bytes.
     ///
-    /// It is up to the user to interprate the slice of memory based on `Data::sample_format`.
+    /// It is up to the user to interpret the slice of memory based on `Data::sample_format`.
     pub fn bytes(&self) -> &[u8] {
         let len = self.len * self.sample_format.sample_size();
+        // The safety of this block relies on correct construction of the `Data` instance. See
+        // the unsafe `from_parts` constructor for these requirements.
         unsafe {
             std::slice::from_raw_parts(self.data as *const u8, len)
         }
@@ -238,9 +248,11 @@ impl Data {
 
     /// The raw slice of memory representing the underlying audio data as a slice of bytes.
     ///
-    /// It is up to the user to interprate the slice of memory based on `Data::sample_format`.
+    /// It is up to the user to interpret the slice of memory based on `Data::sample_format`.
     pub fn bytes_mut(&mut self) -> &mut [u8] {
         let len = self.len * self.sample_format.sample_size();
+        // The safety of this block relies on correct construction of the `Data` instance. See
+        // the unsafe `from_parts` constructor for these requirements.
         unsafe {
             std::slice::from_raw_parts_mut(self.data as *mut u8, len)
         }
@@ -254,6 +266,8 @@ impl Data {
         T: Sample,
     {
         if T::FORMAT == self.sample_format {
+            // The safety of this block relies on correct construction of the `Data` instance. See
+            // the unsafe `from_parts` constructor for these requirements.
             unsafe {
                 Some(std::slice::from_raw_parts(self.data as *const T, self.len))
             }
@@ -270,6 +284,8 @@ impl Data {
         T: Sample,
     {
         if T::FORMAT == self.sample_format {
+            // The safety of this block relies on correct construction of the `Data` instance. See
+            // the unsafe `from_parts` constructor for these requirements.
             unsafe {
                 Some(std::slice::from_raw_parts_mut(self.data as *mut T, self.len))
             }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -255,15 +255,14 @@ macro_rules! impl_platform_host {
                 }
             }
 
-            fn build_input_stream<T, D, E>(
+            fn build_input_stream<D, E>(
                 &self,
                 format: &crate::Format,
                 data_callback: D,
                 error_callback: E,
             ) -> Result<Self::Stream, crate::BuildStreamError>
             where
-                T: crate::Sample,
-                D: FnMut(crate::InputData<T>) + Send + 'static,
+                D: FnMut(&crate::Data) + Send + 'static,
                 E: FnMut(crate::StreamError) + Send + 'static,
             {
                 match self.0 {
@@ -275,15 +274,14 @@ macro_rules! impl_platform_host {
                 }
             }
 
-            fn build_output_stream<T, D, E>(
+            fn build_output_stream<D, E>(
                 &self,
                 format: &crate::Format,
                 data_callback: D,
                 error_callback: E,
             ) -> Result<Self::Stream, crate::BuildStreamError>
             where
-                T: crate::Sample,
-                D: FnMut(crate::OutputData<T>) + Send + 'static,
+                D: FnMut(&mut crate::Data) + Send + 'static,
                 E: FnMut(crate::StreamError) + Send + 'static,
             {
                 match self.0 {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,17 +2,15 @@
 
 use {
     BuildStreamError,
+    Data,
     DefaultFormatError,
     DeviceNameError,
     DevicesError,
     Format,
-    InputData,
     InputDevices,
-    OutputData,
     OutputDevices,
     PauseStreamError,
     PlayStreamError,
-    Sample,
     StreamError,
     SupportedFormat,
     SupportedFormatsError,
@@ -120,27 +118,25 @@ pub trait DeviceTrait {
     fn default_output_format(&self) -> Result<Format, DefaultFormatError>;
 
     /// Create an input stream.
-    fn build_input_stream<T, D, E>(
+    fn build_input_stream<D, E>(
         &self,
         format: &Format,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
     where
-        T: Sample,
-        D: FnMut(InputData<T>) + Send + 'static,
+        D: FnMut(&Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static;
 
     /// Create an output stream.
-    fn build_output_stream<T, D, E>(
+    fn build_output_stream<D, E>(
         &self,
         format: &Format,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
     where
-        T: Sample,
-        D: FnMut(OutputData<T>) + Send + 'static,
+        D: FnMut(&mut Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static;
 }
 


### PR DESCRIPTION
This is a potential alternative to rustaudio/cpal#359. This PR is based on rustaudio/cpal#359.

This approach opts for a dynamically checked sample type approach with
the aim of minimising compile time and binary size.

You can read more discussion on this [here](https://github.com/RustAudio/cpal/pull/359#issuecomment-575931461).

The main difference is the `Data` type, provided to the input and output stream data callbacks via `&Data` and `&mut Data` respectively. It no longer contains the sample type in the type, but still allows for typed access to the data via its methods. The aim is to remove the need for monomorphisation of the entire `build_input/output_stream` methods, while still providing easy type-safe access to the data.

The type provides the following methods:

- `pub fn sample_format(&self) -> SampleFormat`
- `pub fn len(&self) -> usize`
- `pub fn bytes(&self) -> &[u8]` raw access to the audio data
- `pub fn bytes_mut(&mut self) -> &mut [u8]`
- `pub fn as_slice<T: Sample>(&self) -> Option<&[T]>` checked typed access to the audio data, returns `None` if sample type does not match sample format.
- `pub fn as_slice_mut<T: Sample>(&mut self) -> Option<&mut [T]>`

Implemented backends:

- [x] null
- [x] ALSA
- [x] CoreAudio
- [x] WASAPI
- [x] ASIO
- [x] Emscripten
- [x] Docs