### PR TITLE
Restrict the ways in which `SupportedStreamConfig/Range`s can be constructed

### DIFF
--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), anyhow::Error> {
         .expect("failed to find a default output device");
     let config = device.default_output_config()?;
 
-    match config.sample_format {
+    match config.sample_format() {
         cpal::SampleFormat::F32 => run::<f32>(&device, &config.into())?,
         cpal::SampleFormat::I16 => run::<i16>(&device, &config.into())?,
         cpal::SampleFormat::U16 => run::<u16>(&device, &config.into())?,

--- a/examples/enumerate.rs
+++ b/examples/enumerate.rs
@@ -22,8 +22,8 @@ fn main() -> Result<(), anyhow::Error> {
             println!("  {}. \"{}\"", device_index + 1, device.name()?);
 
             // Input configs
-            if let Ok(fmt) = device.default_input_config() {
-                println!("    Default input stream config:\n      {:?}", fmt);
+            if let Ok(conf) = device.default_input_config() {
+                println!("    Default input stream config:\n      {:?}", conf);
             }
             let mut input_configs = match device.supported_input_configs() {
                 Ok(f) => f.peekable(),
@@ -45,8 +45,8 @@ fn main() -> Result<(), anyhow::Error> {
             }
 
             // Output configs
-            if let Ok(fmt) = device.default_output_config() {
-                println!("    Default output stream config:\n      {:?}", fmt);
+            if let Ok(conf) = device.default_output_config() {
+                println!("    Default output stream config:\n      {:?}", conf);
             }
             let mut output_configs = match device.supported_output_configs() {
                 Ok(f) => f.peekable(),

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), anyhow::Error> {
         eprintln!("an error occurred on stream: {}", err);
     };
 
-    let stream = match config.sample_format {
+    let stream = match config.sample_format() {
         cpal::SampleFormat::F32 => device.build_input_stream(
             &config.into(),
             move |data| write_input_data::<f32, f32>(data, &writer_2),
@@ -78,10 +78,10 @@ fn sample_format(format: cpal::SampleFormat) -> hound::SampleFormat {
 
 fn wav_spec_from_config(config: &cpal::SupportedStreamConfig) -> hound::WavSpec {
     hound::WavSpec {
-        channels: config.channels as _,
-        sample_rate: config.sample_rate.0 as _,
-        bits_per_sample: (config.sample_format.sample_size() * 8) as _,
-        sample_format: sample_format(config.sample_format),
+        channels: config.channels() as _,
+        sample_rate: config.sample_rate().0 as _,
+        bits_per_sample: (config.sample_format().sample_size() * 8) as _,
+        sample_format: sample_format(config.sample_format()),
     }
 }
 

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -3,8 +3,8 @@ extern crate parking_lot;
 
 use crate::{
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
-    PauseStreamError, PlayStreamError, StreamError, SupportedStreamConfig,
-    SupportedStreamConfigsError,
+    PauseStreamError, PlayStreamError, SampleFormat, StreamConfig, StreamError,
+    SupportedStreamConfig, SupportedStreamConfigsError,
 };
 use traits::{DeviceTrait, HostTrait, StreamTrait};
 
@@ -84,7 +84,8 @@ impl DeviceTrait for Device {
 
     fn build_input_stream_raw<D, E>(
         &self,
-        config: &SupportedStreamConfig,
+        config: &StreamConfig,
+        sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
@@ -92,12 +93,13 @@ impl DeviceTrait for Device {
         D: FnMut(&Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        Device::build_input_stream_raw(self, config, data_callback, error_callback)
+        Device::build_input_stream_raw(self, config, sample_format, data_callback, error_callback)
     }
 
     fn build_output_stream_raw<D, E>(
         &self,
-        config: &SupportedStreamConfig,
+        config: &StreamConfig,
+        sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
@@ -105,7 +107,7 @@ impl DeviceTrait for Device {
         D: FnMut(&mut Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        Device::build_output_stream_raw(self, config, data_callback, error_callback)
+        Device::build_output_stream_raw(self, config, sample_format, data_callback, error_callback)
     }
 }
 

--- a/src/host/emscripten/mod.rs
+++ b/src/host/emscripten/mod.rs
@@ -9,8 +9,8 @@ use stdweb::Reference;
 
 use crate::{
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
-    PauseStreamError, PlayStreamError, SampleFormat, StreamError, SupportedStreamConfig,
-    SupportedStreamConfigRange, SupportedStreamConfigsError,
+    PauseStreamError, PlayStreamError, SampleFormat, StreamConfig, StreamError,
+    SupportedStreamConfig, SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 use traits::{DeviceTrait, HostTrait, StreamTrait};
 
@@ -154,7 +154,8 @@ impl DeviceTrait for Device {
 
     fn build_input_stream_raw<D, E>(
         &self,
-        _config: &SupportedStreamConfig,
+        _config: &StreamConfig,
+        _sample_format: SampleFormat,
         _data_callback: D,
         _error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
@@ -167,7 +168,8 @@ impl DeviceTrait for Device {
 
     fn build_output_stream_raw<D, E>(
         &self,
-        config: &SupportedStreamConfig,
+        _config: &StreamConfig,
+        sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
@@ -176,7 +178,7 @@ impl DeviceTrait for Device {
         E: FnMut(StreamError) + Send + 'static,
     {
         assert_eq!(
-            config.sample_format,
+            sample_format,
             SampleFormat::F32,
             "emscripten backend currently only supports `f32` data",
         );

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
-    PauseStreamError, PlayStreamError, StreamError, SupportedStreamConfig,
-    SupportedStreamConfigRange, SupportedStreamConfigsError,
+    PauseStreamError, PlayStreamError, SampleFormat, StreamConfig, StreamError,
+    SupportedStreamConfig, SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 use traits::{DeviceTrait, HostTrait, StreamTrait};
 
@@ -68,7 +68,8 @@ impl DeviceTrait for Device {
 
     fn build_input_stream_raw<D, E>(
         &self,
-        _format: &SupportedStreamConfig,
+        _config: &StreamConfig,
+        _sample_format: SampleFormat,
         _data_callback: D,
         _error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
@@ -82,7 +83,8 @@ impl DeviceTrait for Device {
     /// Create an output stream.
     fn build_output_stream_raw<D, E>(
         &self,
-        _format: &SupportedStreamConfig,
+        _config: &StreamConfig,
+        _sample_format: SampleFormat,
         _data_callback: D,
         _error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,13 +191,13 @@ pub struct StreamConfig {
 /// `Device::supported_input/output_configs` method.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SupportedStreamConfigRange {
-    pub channels: ChannelCount,
+    pub(crate) channels: ChannelCount,
     /// Minimum value for the samples rate of the supported formats.
-    pub min_sample_rate: SampleRate,
+    pub(crate) min_sample_rate: SampleRate,
     /// Maximum value for the samples rate of the supported formats.
-    pub max_sample_rate: SampleRate,
+    pub(crate) max_sample_rate: SampleRate,
     /// Type of data expected by the device.
-    pub sample_format: SampleFormat,
+    pub(crate) sample_format: SampleFormat,
 }
 
 /// Describes a single supported stream configuration, retrieved via either a
@@ -335,6 +335,35 @@ impl Data {
 }
 
 impl SupportedStreamConfigRange {
+    pub fn channels(&self) -> ChannelCount {
+        self.channels
+    }
+
+    pub fn min_sample_rate(&self) -> SampleRate {
+        self.min_sample_rate
+    }
+
+    pub fn max_sample_rate(&self) -> SampleRate {
+        self.max_sample_rate
+    }
+
+    pub fn sample_format(&self) -> SampleFormat {
+        self.sample_format
+    }
+
+    /// Retrieve a `SupportedStreamConfig` with the given sample rate.
+    ///
+    /// **panic!**s if the given `sample_rate` is outside the range specified within this
+    /// `SupportedStreamConfigRange` instance.
+    pub fn with_sample_rate(self, sample_rate: SampleRate) -> SupportedStreamConfig {
+        assert!(sample_rate <= self.min_sample_rate && sample_rate <= self.max_sample_rate);
+        SupportedStreamConfig {
+            channels: self.channels,
+            sample_format: self.sample_format,
+            sample_rate,
+        }
+    }
+
     /// Turns this `SupportedStreamConfigRange` into a `SupportedStreamConfig` corresponding to the maximum samples rate.
     #[inline]
     pub fn with_max_sample_rate(self) -> SupportedStreamConfig {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -257,7 +257,8 @@ macro_rules! impl_platform_host {
 
             fn build_input_stream_raw<D, E>(
                 &self,
-                format: &crate::SupportedStreamConfig,
+                config: &crate::StreamConfig,
+                sample_format: crate::SampleFormat,
                 data_callback: D,
                 error_callback: E,
             ) -> Result<Self::Stream, crate::BuildStreamError>
@@ -267,7 +268,13 @@ macro_rules! impl_platform_host {
             {
                 match self.0 {
                     $(
-                        DeviceInner::$HostVariant(ref d) => d.build_input_stream_raw(format, data_callback, error_callback)
+                        DeviceInner::$HostVariant(ref d) => d
+                            .build_input_stream_raw(
+                                config,
+                                sample_format,
+                                data_callback,
+                                error_callback,
+                            )
                             .map(StreamInner::$HostVariant)
                             .map(Stream::from),
                     )*
@@ -276,7 +283,8 @@ macro_rules! impl_platform_host {
 
             fn build_output_stream_raw<D, E>(
                 &self,
-                format: &crate::SupportedStreamConfig,
+                config: &crate::StreamConfig,
+                sample_format: crate::SampleFormat,
                 data_callback: D,
                 error_callback: E,
             ) -> Result<Self::Stream, crate::BuildStreamError>
@@ -286,7 +294,13 @@ macro_rules! impl_platform_host {
             {
                 match self.0 {
                     $(
-                        DeviceInner::$HostVariant(ref d) => d.build_output_stream_raw(format, data_callback, error_callback)
+                        DeviceInner::$HostVariant(ref d) => d
+                            .build_output_stream_raw(
+                                config,
+                                sample_format,
+                                data_callback,
+                                error_callback,
+                            )
                             .map(StreamInner::$HostVariant)
                             .map(Stream::from),
                     )*

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,8 +2,8 @@
 
 use {
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError, InputDevices,
-    OutputDevices, PauseStreamError, PlayStreamError, Sample, StreamConfig, StreamError,
-    SupportedStreamConfig, SupportedStreamConfigRange, SupportedStreamConfigsError,
+    OutputDevices, PauseStreamError, PlayStreamError, Sample, SampleFormat, StreamConfig,
+    StreamError, SupportedStreamConfig, SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 
 /// A **Host** provides access to the available audio devices on the system.
@@ -126,7 +126,8 @@ pub trait DeviceTrait {
         E: FnMut(StreamError) + Send + 'static,
     {
         self.build_input_stream_raw(
-            &SupportedStreamConfig::from_config(config, T::FORMAT),
+            config,
+            T::FORMAT,
             move |data| {
                 data_callback(
                     data.as_slice()
@@ -150,7 +151,8 @@ pub trait DeviceTrait {
         E: FnMut(StreamError) + Send + 'static,
     {
         self.build_output_stream_raw(
-            &SupportedStreamConfig::from_config(config, T::FORMAT),
+            config,
+            T::FORMAT,
             move |data| {
                 data_callback(
                     data.as_slice_mut()
@@ -164,7 +166,8 @@ pub trait DeviceTrait {
     /// Create a dynamically typed input stream.
     fn build_input_stream_raw<D, E>(
         &self,
-        format: &SupportedStreamConfig,
+        config: &StreamConfig,
+        sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
@@ -175,7 +178,8 @@ pub trait DeviceTrait {
     /// Create a dynamically typed output stream.
     fn build_output_stream_raw<D, E>(
         &self,
-        format: &SupportedStreamConfig,
+        config: &StreamConfig,
+        sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>


### PR DESCRIPTION
Based on RustAudio#371.

This should give the user a higher confidence that, if they have a
`SupportedStreamConfig` format type that it is actually supported.
Aimed at addressing the issue raised [here](https://github.com/RustAudio/cpal/pull/371#discussion_r373110855).

This does not address the issue where a `SupportedStreamConfig` might
have been constructed from a different `Device`.

Also updates the `raw` stream builder methods to take a `StreamConfig`
and `SampleFormat` as separate arguments for flexibility.

cc @msiglreith @Ralith