### PR TITLE
WIP - Add ALSA timestamp implementation.

### DIFF
--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -204,6 +204,7 @@ impl Device {
         };
 
         // Check to see if we can retrieve valid timestamps from the device.
+        // Related: https://bugs.freedesktop.org/show_bug.cgi?id=88503
         let ts = handle.status()?.get_htstamp();
         let creation_instant = match (ts.tv_sec, ts.tv_nsec) {
             (0, 0) => Some(std::time::Instant::now()),
@@ -741,8 +742,6 @@ fn stream_timestamp(stream: &StreamInner) -> Result<crate::StreamInstant, Backen
         None => {
             let status = stream.channel.status()?;
             let trigger_ts = status.get_trigger_htstamp();
-            // TODO: This is returning `0` on ALSA where default device forwards to pulse.
-            // Possibly related: https://bugs.freedesktop.org/show_bug.cgi?id=88503
             let ts = status.get_htstamp();
             let nanos = timespec_diff_nanos(ts, trigger_ts)
                 .try_into()


### PR DESCRIPTION
I think this is mostly complete, however there are two major TODOs:

- There seems to be a bug where timestamps are not reported when the
  target device is `pulse`. This causes a `panic!` as the trigger
  timestamp should always precede the timestamp when retrieved while the
  stream is running.
  https://bugs.freedesktop.org/show_bug.cgi?id=88503
- We need to specify the timestamp type as MONOTONIC_RAW, however the
  `alsa` and `alsa-sys` crates do not yet expose the necessary
  `set_tstamp_type` function. https://github.com/diwic/alsa-sys/issues/6